### PR TITLE
Review layout to make sure buttons adapt to their contents, for long translations

### DIFF
--- a/library/src/main/res/layout/siren_dialog.xml
+++ b/library/src/main/res/layout/siren_dialog.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <TextView
         android:id="@+id/tvSirenAlertMessage"
@@ -19,12 +18,14 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
-        android:layout_marginTop="20dp">
+        android:layout_gravity="center"
+        android:layout_below="@+id/tvSirenAlertMessage">
 
         <Button
             android:id="@+id/btnSirenNextTime"
             android:layout_width="0dp"
-            android:layout_height="@dimen/button_height"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
             android:layout_marginLeft="@dimen/half_margin"
             android:layout_marginRight="@dimen/half_margin"
             android:layout_weight="1"
@@ -35,23 +36,23 @@
         <Button
             android:id="@+id/btnSirenUpdate"
             android:layout_width="0dp"
-            android:layout_height="@dimen/button_height"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
             android:layout_marginLeft="@dimen/half_margin"
             android:layout_marginRight="@dimen/half_margin"
             android:layout_weight="1"
             android:text="@string/update"
             tools:ignore="ButtonStyle" />
 
-
     </LinearLayout>
     <Button
         android:id="@+id/btnSirenSkip"
         android:layout_width="match_parent"
-        android:layout_height="@dimen/button_height"
+        android:layout_height="wrap_content"
         android:layout_marginLeft="@dimen/half_margin"
         android:layout_marginRight="@dimen/half_margin"
         android:text="@string/skip_this_version"
-        android:visibility="gone"/>
+        android:visibility="gone"
+        android:layout_below="@+id/llSirenButtonsContainer" />
 
-
-</LinearLayout>
+</RelativeLayout>

--- a/library/src/main/res/values/dimen.xml
+++ b/library/src/main/res/values/dimen.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <dimen name="button_height">48dp</dimen>
-</resources>


### PR DESCRIPTION
As texts may be cut in buttons for some languages like French and Russian (see Issue #23), I made sure buttons adapt to their contents by:

* using a relative layout
* no longer using fixed heights for buttons, instead using `wrap_content` for  their layout heights
* getting rid of no longer necessary `dimen.xml` file
