### PR TITLE
Feature: Get app version from Google Play Store rather than hosting a json

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'com.android.tools.build:gradle:3.1.4'
+        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }
@@ -15,6 +16,10 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        mavenCentral()
+        google()
+
+        maven { url "https://jitpack.io" }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply from: "quality.gradle"
 
-group = 'com.github.robertofrontado'
+group = 'com.github.eggheadgames'
 
 android {
     compileSdkVersion 25

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 13
-        versionName "1.6.3"
+        versionName "1.7.0"
     }
     buildTypes {
         release {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,17 +2,16 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 apply from: "quality.gradle"
 
-group = 'com.github.eggheadgames'
+group = 'com.github.robertofrontado'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.1"
 
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion 25
         versionCode 13
-        versionName "1.5.2"
+        versionName "1.6.3"
     }
     buildTypes {
         release {
@@ -29,11 +28,12 @@ android {
 }
 
 dependencies {
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
-    testCompile 'org.json:json:20160212'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:1.10.19'
+    testImplementation 'org.json:json:20160212'
 
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     //noinspection GradleDependency
-    compile 'com.android.support:appcompat-v7:25.0.0'
+    implementation 'com.android.support:appcompat-v7:25.0.0'
+    implementation 'org.jsoup:jsoup:1.11.3'
 }

--- a/library/quality.gradle
+++ b/library/quality.gradle
@@ -13,7 +13,7 @@ pmd {
   reportsDir = file("$project.buildDir/outputs/")
 }
 
-task findbugs(type: FindBugs, dependsOn: assembleDebug) {
+task findbugs(type: FindBugs, dependsOn: "assembleDebug") {
   description 'Run findbugs'
   group 'verification'
 
@@ -31,7 +31,7 @@ task findbugs(type: FindBugs, dependsOn: assembleDebug) {
   }
 }
 
-task pmd(type: Pmd, dependsOn: assembleDebug) {
+task pmd(type: Pmd, dependsOn: "assembleDebug") {
   description 'Run pmd'
   group 'verification'
 


### PR DESCRIPTION
I really like this library 👍 Very nice work!

But I realized that it didn't work the same way as the [iOS version](https://github.com/ArtSabintsev/Siren) 

So I added this is the new method:

```java 
public void checkVersion(Activity activity, SirenVersionCheckType versionCheckType) {
...
}
```

So there is no need to pass the url of the json 🙌 

**Note:** I added this as an extra functionality, so if you still want to keep the updates alerts via json you can 👍 